### PR TITLE
Update ItemGun.java

### DIFF
--- a/src/main/java/com/flansmod/common/guns/ItemGun.java
+++ b/src/main/java/com/flansmod/common/guns/ItemGun.java
@@ -352,7 +352,10 @@ public class ItemGun extends Item implements IPaintableItem
 					//PlayerData burst rounds handled on client
 					if(hold && !held)
 					{
-						data.SetBurstTicksRemaining(hand, (int) (Math.max(type.shootDelay, 1.5F) * 3));
+						if(type.mode != EnumFireMode.BURST)
+							data.SetBurstTicksRemaining(hand, (int) (Math.max(type.shootDelay, 1.5F) * 3));
+						else
+							data.SetBurstTicksRemaining(hand, (int) type.shootDelay * 3);
 					}
 					else if(held)
 					{


### PR DESCRIPTION
fixed so that guns set to burst by default can shoot faster than the 1.5 tick limit that should only be imposed on the guns with the modification